### PR TITLE
Add week interval to Date Convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ or a sequence at root :
 <a name="dateconvert"></a>
 ## Date Convert
 
-Display date in __differents formats__ and convert _unix timestamp_ or date string. You can also __calculate an interval__, exemple: _+1d or -5h (h:hour, d:day, m:month)._
+Display date in __differents formats__ and convert _unix timestamp_ or date string. You can also __calculate an interval__, example: _+1d or -5h (h:hour, d:day, m:month)._
 
 Press space bar to enter a date and __clicking on the date__ put content on the clipboard.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ or a sequence at root :
 <a name="dateconvert"></a>
 ## Date Convert
 
-Display date in __differents formats__ and convert _unix timestamp_ or date string. You can also __calculate an interval__, example: _+1d or -5h (h:hour, d:day, m:month)._
+Display date in __differents formats__ and convert _unix timestamp_ or date string. You can also __calculate an interval__, example: _+1d or -5h (h:hour, d:day, w:week, m:month)._
 
 Press space bar to enter a date and __clicking on the date__ put content on the clipboard.
 

--- a/UnixDate.lbaction/Contents/Scripts/UnixDate.rb
+++ b/UnixDate.lbaction/Contents/Scripts/UnixDate.rb
@@ -38,6 +38,11 @@ class UnixDate
 			offset = date.to_i
 			actualdate = @thedate.to_time.to_i
 			@thedate = Time.at(actualdate+(offset*3600)).to_datetime
+		elsif /^[+-]+[0-9]+w/ =~ date
+			# Week Offset
+			today
+			offset = date.to_i * 7
+			@thedate = @thedate + offset
 		else
 			# Date string
 			begin


### PR DESCRIPTION
[Date Convert](https://github.com/atika/LaunchBar-Actions/blob/431be7b472839b44dbd59310d7e175e5cae89bf5/README.md#date-convert) currently supports hour, day, and month intervals:

> You can also **calculate an interval**, example: _+1d or -5h (h:hour, d:day, m:month)._

This pull request adds support for week intervals.
